### PR TITLE
Refactor the export api and improve error messages

### DIFF
--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -616,6 +616,7 @@ def exported_program_to_ir(
 
         # Include explicit type promotion nodes
         _fx_passes.insert_type_promotion_nodes(exported_program)
+        _fx_passes.remove_assertion_nodes(exported_program)
     values = _add_nodes(exported_program, model, lower=lower, registry=registry)
 
     # 2. Add user inputs and all parameters/buffers to the graph.

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -6,6 +6,7 @@ import inspect
 import itertools
 import logging
 import operator
+import textwrap
 import traceback
 import typing
 from typing import Any, Literal, Sequence
@@ -808,12 +809,13 @@ def export(
                 error_report_path = None
 
             raise errors.TorchExportError(
-                "Failed to export the model with torch.export. "
-                f"{_BLUE}This is step 1/2{_END} "
-                "of exporting the model to ONNX. Please create an issue "
-                f"in the PyTorch GitHub repository against the {_BLUE}*torch.export*{_END} component and "
-                "attach the full error stack as well as reproduction scripts."
-                + f" Error report has been saved to '{error_report_path}'."
+                textwrap.dedent(f"""\
+                    Failed to export the model with torch.export. {_BLUE}This is step 1/2{_END} of exporting the model to ONNX. Next steps:
+                    - Modify the model code for `torch.export.export` to succeed.
+                    - Debug `torch.export.export` and summit a PR to PyTorch.
+                    - Create an issue in the PyTorch GitHub repository against the {_BLUE}*torch.export*{_END} component and attach the full error stack as well as reproduction scripts.
+                    """)
+                + f"Error report has been saved to '{error_report_path}'."
                 if error_report
                 else ""
             ) from e
@@ -854,14 +856,14 @@ def export(
             error_report_path = None
 
         raise errors.OnnxConversionError(
-            "Failed to convert the exported program to an ONNX model. "
-            f"{_BLUE}This is step 2/2{_END} "
-            "of exporting the model to ONNX. Please create an issue "
-            f"in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component and "
-            "attach the full error stack as well as reproduction scripts. "
-            "You can run `torch_onnx.analyze()` to produce an error report after obtaining "
-            "an ExportedProgram with `torch.export.export()`."
-            + f" Error report has been saved to '{error_report_path}'."
+            textwrap.dedent(f"""\
+                Failed to convert the exported program to an ONNX model. {_BLUE}This is step 2/2{_END} of exporting the model to ONNX. Next steps:
+                - If there is a missing ONNX function, implement it and register it to the registry.
+                - If there is an internal error during ONNX conversion, debug the error and summit a PR to PyTorch.
+                - You can run `torch_onnx.analyze()` to produce an error report after obtaining the ExportedProgram with `torch.export.export()`.
+                - Run export with `error_report=True` and create an issue in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component and attach error report as well as reproduction scripts.
+                """)
+            + f"Error report has been saved to '{error_report_path}'."
             if error_report
             else ""
         ) from e

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -848,6 +848,7 @@ def export(
                 program,
                 step=1,
                 profile_result=profile_result,
+                registry=registry,
             )
         else:
             error_report_path = None
@@ -892,7 +893,8 @@ def export(
                 onnx_program.exported_program,
                 step=2,
                 profile_result=profile_result,
-                ir_model=onnx_program.model,
+                model=onnx_program.model,
+                registry=registry,
             )
         logger.warning(
             "Conversion successful but the ONNX model fails ONNX checker. "  # noqa: G004

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -860,8 +860,7 @@ def export(
                 Failed to convert the exported program to an ONNX model. {_BLUE}This is step 2/2{_END} of exporting the model to ONNX. Next steps:
                 - If there is a missing ONNX function, implement it and register it to the registry.
                 - If there is an internal error during ONNX conversion, debug the error and summit a PR to PyTorch.
-                - You can run `torch_onnx.analyze()` to produce an error report after obtaining the ExportedProgram with `torch.export.export()`.
-                - Run export with `error_report=True` and create an issue in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component and attach error report as well as reproduction scripts.
+                - Save the ExportedProgram as a pt2 file and create an error report with `export(error_report=True)`. Create an issue in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component. Attach the pt2 model and the error report.
                 """)
             + f"Error report has been saved to '{error_report_path}'."
             if error_report

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -753,10 +753,10 @@ def export(
     args: tuple[Any, ...],
     kwargs: dict[str, Any] | None = None,
     *,
+    registry: _registration.OnnxRegistry | None = None,
+    dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any] | None = None,
     input_names: Sequence[str] | None = None,
     output_names: Sequence[str] | None = None,
-    opset_version: int | None = None,
-    dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any] | None = None,
     profile: bool = False,
     error_report: bool = False,
 ) -> _onnx_program.ONNXProgram:
@@ -766,15 +766,15 @@ def export(
         model: The model to export. This can be a PyTorch nn.Module or an ExportedProgram.
         args: The arguments to pass to the model.
         kwargs: The keyword arguments to pass to the model.
+        registry: The registry of all ONNX decompositions.
+        dynamic_shapes: Dynamic shapes in the graph.
         input_names: If provided, rename the inputs.
         output_names: If provided, rename the outputs.
-        opset_version: The ONNX opset version to use.
-        dynamic_shapes: Dynamic shapes in the graph.
         profile: Whether to profile the export process.
         error_report: Whether to generate an error report if the export fails.
 
     Returns:
-        The ONNXProgram.
+        The ONNXProgram with the exported IR graph.
 
     Raises:
         TorchExportError: If the export process fails with torch.export.
@@ -825,7 +825,7 @@ def export(
     # Step 1: Convert the exported program to an ONNX model
     try:
         print("Translate the graph into ONNX... ", end="", flush=True)
-        ir_model = exported_program_to_ir(program)
+        ir_model = exported_program_to_ir(program, registry=registry)
 
         if input_names:
             _ir_passes.rename_inputs(ir_model, input_names)

--- a/src/torch_onnx/_dispatching.py
+++ b/src/torch_onnx/_dispatching.py
@@ -251,11 +251,13 @@ def get_matching_overload(
                 ):
                     first_tensor = _get_first_tensor_in_node_list(arg)
                     assert first_tensor is not None
+                    # FIXME: Handle symfloat here
                     arg = ir.SequenceType(_get_type_from_tensor(first_tensor))
                 elif isinstance(arg, torch.fx.Node):
                     meta_val = arg.meta["val"]
                     arg = _get_type_from_tensor(meta_val)
                 # TODO: Handle None attributes
+                # FIXME: Handle symfloat etc.
                 # Handle tensors and Python values
                 if not _param_type_compatible_with_arg(param, arg, assigned_types):
                     fail_reason = f"Parameter type not compatible with argument: param=`{param}`, assigned_types=`{assigned_types}`, arg=`{arg}`"

--- a/src/torch_onnx/_fx_passes.py
+++ b/src/torch_onnx/_fx_passes.py
@@ -2,11 +2,25 @@ import torch
 import torch.export
 from torch.onnx._internal.fx import diagnostics, passes
 
+_ATEN_ASSERTION_TARGETS = frozenset(
+    {
+        torch.ops.aten.sym_constrain_range_for_size.default,
+        torch.ops.aten._assert_async.msg,
+    }
+)
 
-def insert_type_promotion_nodes(exported_program: torch.export.ExportedProgram):
+
+def insert_type_promotion_nodes(exported_program: torch.export.ExportedProgram) -> None:
     """Inplace pass to insert explicit type promotion nodes."""
     diagnostic_context = diagnostics.DiagnosticContext(
         "torch.onnx.export",
         torch.__version__,
     )
     passes.InsertTypePromotion(diagnostic_context, exported_program.graph_module).run()
+
+
+def remove_assertion_nodes(exported_program: torch.export.ExportedProgram) -> None:
+    """Remove all assertion and check nodes from the FX graph"""
+    for node in exported_program.graph.nodes:
+        if node.op == "call_function" and node.target in _ATEN_ASSERTION_TARGETS:
+            exported_program.graph.erase_node(node)

--- a/src/torch_onnx/_patch.py
+++ b/src/torch_onnx/_patch.py
@@ -17,8 +17,6 @@ import torch.export
 import torch_onnx
 from torch_onnx import _ir_passes, _onnx_program, _reporting, errors
 
-_BLUE = "\033[96m"
-_END = "\033[0m"
 
 logger = logging.getLogger(__name__)
 
@@ -105,25 +103,6 @@ def _get_torch_export_args(
     return args, kwargs, dynamic_shapes
 
 
-def _maybe_start_profiler(should_profile: bool) -> Any:
-    if should_profile:
-        import pyinstrument
-
-        profiler = pyinstrument.Profiler(async_mode="disabled")
-        profiler.start()
-        return profiler
-    return None
-
-
-def _maybe_stop_profiler_and_get_result(profiler) -> str | None:
-    if profiler is None:
-        return None
-    profiler.stop()
-    return profiler.output_text(unicode=True)
-
-
-def _format_exception(e: Exception) -> str:
-    return "\n".join(traceback.format_exception(type(e), e, e.__traceback__))
 
 
 def _torch_onnx_export(
@@ -146,8 +125,7 @@ def _torch_onnx_export(
     # Set up the error reporting facilities
     error_report = WRITE_ERROR_REPORT or error_report
     profile = WRITE_PROFILE_REPORT or profile
-    timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S-%f")
-    profiler = _maybe_start_profiler(profile)
+
 
     # Step 0: Export the model with torch.export.export if the model is not already an ExportedProgram
     if not isinstance(model, torch.export.ExportedProgram):

--- a/src/torch_onnx/_patch.py
+++ b/src/torch_onnx/_patch.py
@@ -2,20 +2,16 @@
 
 from __future__ import annotations
 
-import datetime
 import inspect
 import io
 import logging
-import traceback
 import warnings
 from typing import Any, Mapping, Sequence
 
-import onnx
 import torch
 import torch.export
 
-import torch_onnx
-from torch_onnx import _ir_passes, _onnx_program, _reporting, errors
+from torch_onnx import _onnx_program, _core
 
 
 logger = logging.getLogger(__name__)
@@ -87,7 +83,7 @@ def _from_dynamic_axes_to_dynamic_shapes(
 
 
 def _get_torch_export_args(
-    model: torch.nn.Module,
+    model: torch.nn.Module | torch.export.ExportedProgram,
     args: tuple[Any, ...],
     kwargs: dict[str, Any] | None,
     dynamic_axes: Mapping[str, Mapping[int, str]] | Mapping[str, Sequence[int]] | None,
@@ -101,8 +97,6 @@ def _get_torch_export_args(
         model, dynamic_axes, input_names
     )
     return args, kwargs, dynamic_shapes
-
-
 
 
 def _torch_onnx_export(
@@ -126,164 +120,29 @@ def _torch_onnx_export(
     error_report = WRITE_ERROR_REPORT or error_report
     profile = WRITE_PROFILE_REPORT or profile
 
-
-    # Step 0: Export the model with torch.export.export if the model is not already an ExportedProgram
     if not isinstance(model, torch.export.ExportedProgram):
         args, kwargs, dynamic_shapes = _get_torch_export_args(
             model, args, kwargs, dynamic_axes, input_names
         )
-        try:
-            print(
-                "Obtain model graph with `torch.export.export`... ", end="", flush=True
-            )
-            program = torch.export.export(
-                model, args, kwargs=kwargs, dynamic_shapes=dynamic_shapes
-            )
-            print("✅")
-        except Exception as e:
-            profile_result = _maybe_stop_profiler_and_get_result(profiler)
-
-            if error_report:
-                error_report_path = f"onnx_export_{timestamp}_pt_export.md"
-                _reporting.create_torch_export_error_report(
-                    error_report_path,
-                    _format_exception(e),
-                    profile_result=profile_result,
-                )
-            else:
-                error_report_path = None
-
-            raise errors.TorchExportError(
-                "Failed to export the model with torch.export. "
-                f"{_BLUE}This is step 1/2{_END} "
-                "of exporting the model to ONNX. Please create an issue "
-                f"in the PyTorch GitHub repository against the {_BLUE}*torch.export*{_END} component and "
-                "attach the full error stack as well as reproduction scripts."
-                + f" Error report has been saved to '{error_report_path}'."
-                if error_report
-                else ""
-            ) from e
     else:
-        print("Obtain model graph with `torch.export.export`... ", end="", flush=True)
-        program = model
-        print("✅")
-
-    # Step 1: Convert the exported program to an ONNX model
-    try:
-        print("Translate the graph into ONNX... ", end="", flush=True)
-        ir_model = torch_onnx.exported_program_to_ir(program)
-
-        if input_names:
-            _ir_passes.rename_inputs(ir_model, input_names)
-        if output_names:
-            _ir_passes.rename_outputs(ir_model, output_names)
-
-        if not export_params:
-            ir_model.graph.initializers.clear()
-
-        onnx_program = _onnx_program.ONNXProgram(ir_model, program)
-        if f is not None:
-            onnx_program.save(f)
-        print("✅")
-
-    except Exception as e:
-        profile_result = _maybe_stop_profiler_and_get_result(profiler)
-
-        if error_report:
-            error_report_path = f"onnx_export_{timestamp}_conversion.md"
-
-            # Run the analysis to get the error report
-            _reporting.create_onnx_export_error_report(
-                error_report_path,
-                _format_exception(e),
-                program,
-                step=1,
-                profile_result=profile_result,
-            )
-        else:
-            error_report_path = None
-
-        raise errors.OnnxConversionError(
-            "Failed to convert the exported program to an ONNX model. "
-            f"{_BLUE}This is step 2/2{_END} "
-            "of exporting the model to ONNX. Please create an issue "
-            f"in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component and "
-            "attach the full error stack as well as reproduction scripts. "
-            "You can run `torch_onnx.analyze()` to produce an error report after obtaining "
-            "an ExportedProgram with `torch.export.export()`."
-            + f" Error report has been saved to '{error_report_path}'."
-            if error_report
-            else ""
-        ) from e
-
-    profile_result = _maybe_stop_profiler_and_get_result(profiler)
-    if not error_report:
-        # Return if error report is not requested
-        if profile:
-            assert profile_result is not None
-            _reporting.crete_onnx_export_profile_report(
-                f"onnx_export_{timestamp}_profile.md",
-                onnx_program.exported_program,
-                profile_result,
-                step=1,
-            )
-        return onnx_program
-
-    # Step 2: (When error report is requested) Check the ONNX model with ONNX checker
-    try:
-        print("Run `onnx.checker` on the ONNX model... ", end="", flush=True)
-        if f is None:
-            onnx.checker.check_model(onnx_program.model_proto, full_check=True)
-        elif not isinstance(f, io.BytesIO):
-            onnx.checker.check_model(f, full_check=True)
-        else:
-            # Reset the file pointer to the beginning
-            f.seek(0)
-            proto = onnx.load_model(f)
-            onnx.checker.check_model(proto, full_check=True)
-        print("✅")
-    except Exception as e:
-        if error_report:
-            _reporting.create_onnx_export_error_report(
-                f"onnx_export_{timestamp}_checker.md",
-                _format_exception(e),
-                onnx_program.exported_program,
-                step=2,
-                profile_result=profile_result,
-                ir_model=onnx_program.model,
-            )
-        logger.warning(
-            "Conversion successful but the ONNX model fails ONNX checker. "  # noqa: G004
-            "Please create an issue "
-            f"in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component and "
-            "attach the full error stack as well as reproduction scripts. ",
-            exc_info=e,
+        args, kwargs, dynamic_shapes = _get_torch_export_args(
+            model, args, kwargs, None, input_names
         )
-        return onnx_program
 
-    # Step 3: (When error report is requested) Execute the model with ONNX Runtime
-    # try:
-    #     print("Execute the model with ONNX Runtime... ", end="", flush=True)
-    #     print("✅")
-    # except Exception as e:
-    #     raise errors.OnnxConversionError(
-    #         "Conversion successful but the ONNX model fails to execute with ONNX Runtime. "
-    #         "Please create an issue "
-    #         f"in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component and "
-    #         "attach the full error stack as well as reproduction scripts. "
-    #     ) from e
+    onnx_program = _core.export(
+        model,
+        args,
+        kwargs,
+        registry=None,
+        dynamic_shapes=dynamic_shapes,
+        input_names=input_names,
+        output_names=output_names,
+        profile=profile,
+        error_report=error_report,
+    )
 
-    # Step 4: (When error report is requested) Validate the output values
-    # TODO
-
-    if profile:
-        assert profile_result is not None
-        _reporting.crete_onnx_export_profile_report(
-            f"onnx_export_{timestamp}_profile.md",
-            onnx_program.exported_program,
-            profile_result,
-            step=2,  # TODO: Update the step number to 4 when validation is implemented
-        )
+    if f is not None:
+        onnx_program.save(f)
 
     return onnx_program
 
@@ -297,7 +156,8 @@ def _torch_onnx_dynamo_export(
 ) -> _onnx_program.ONNXProgram:
     if export_options and export_options.dynamic_shapes:
         warnings.warn("Dynamic shapes are not implemented yet.", stacklevel=1)
-    return _torch_onnx_export(
+
+    return _core.export(
         model,
         model_args,
         kwargs=model_kwargs,

--- a/src/torch_onnx/_reporting.py
+++ b/src/torch_onnx/_reporting.py
@@ -1,6 +1,6 @@
 import torch
 
-from torch_onnx import _analysis
+from torch_onnx import _analysis, _registration
 from onnxscript import ir
 
 
@@ -47,7 +47,8 @@ def create_onnx_export_error_report(
     *,
     step: int,
     profile_result: str | None,
-    ir_model: ir.Model | None = None,
+    model: ir.Model | None = None,
+    registry: _registration.OnnxRegistry | None = None,
 ):
     with open(filename, "w", encoding="utf-8") as f:
         f.write("# PyTorch ONNX Conversion Error Report\n\n")
@@ -60,13 +61,13 @@ def create_onnx_export_error_report(
         f.write("```python\n")
         f.write(str(program))
         f.write("```\n\n")
-        if ir_model is not None:
+        if model is not None:
             f.write("ONNX model:\n\n")
             f.write("```python\n")
-            f.write(str(ir_model))
+            f.write(str(model))
             f.write("\n```\n\n")
         f.write("## Analysis\n\n")
-        _analysis.analyze(program, file=f)
+        _analysis.analyze(program, file=f, registry=registry)
         if profile_result is not None:
             f.write("\n## Profiling result\n\n")
             f.write("```\n")

--- a/tests/torch_tests/onnx_test_common.py
+++ b/tests/torch_tests/onnx_test_common.py
@@ -36,6 +36,9 @@ from torch.testing._internal import common_utils
 from torch.testing._internal.opinfo import core as opinfo_core
 from torch.types import Number
 
+import torch_onnx
+import torch_onnx.errors
+
 _NumericType = Union[Number, torch.Tensor, np.ndarray]
 _ModelType = Union[torch.nn.Module, Callable, torch_export.ExportedProgram]
 _InputArgsType = Optional[
@@ -160,25 +163,28 @@ class _TestONNXRuntime(pytorch_test_common.ExportTestCase):
         verbose=False,
     ):
         def _run_test(m, remained_onnx_input_idx, flatten=True, ignore_none=True):
-            return run_model_test(
-                self,
-                m,
-                input_args=input_args,
-                input_kwargs=input_kwargs,
-                rtol=rtol,
-                atol=atol,
-                do_constant_folding=do_constant_folding,
-                dynamic_axes=dynamic_axes,
-                additional_test_inputs=additional_test_inputs,
-                input_names=input_names,
-                output_names=output_names,
-                fixed_batch_size=fixed_batch_size,
-                training=training,
-                remained_onnx_input_idx=remained_onnx_input_idx,
-                flatten=flatten,
-                ignore_none=ignore_none,
-                verbose=verbose,
-            )
+            try:
+                return run_model_test(
+                    self,
+                    m,
+                    input_args=input_args,
+                    input_kwargs=input_kwargs,
+                    rtol=rtol,
+                    atol=atol,
+                    do_constant_folding=do_constant_folding,
+                    dynamic_axes=dynamic_axes,
+                    additional_test_inputs=additional_test_inputs,
+                    input_names=input_names,
+                    output_names=output_names,
+                    fixed_batch_size=fixed_batch_size,
+                    training=training,
+                    remained_onnx_input_idx=remained_onnx_input_idx,
+                    flatten=flatten,
+                    ignore_none=ignore_none,
+                    verbose=verbose,
+                )
+            except torch_onnx.errors.TorchExportError:
+                self.skipTest("torch.export errors are skipped")
 
         if isinstance(remained_onnx_input_idx, dict):
             scripting_remained_onnx_input_idx = remained_onnx_input_idx["scripting"]


### PR DESCRIPTION
Improved error messages to provide clear next steps when there is an export error

```
E           torch_onnx.errors.OnnxConversionError: Failed to convert the exported program to an ONNX model. This is step 2/2 of exporting the model to ONNX. Next steps:
E           - If there is a missing ONNX function, implement it and register it to the registry.
E           - If there is an internal error during ONNX conversion, debug the error and summit a PR to PyTorch.
E           - Save the ExportedProgram as a pt2 file and create an error report with `export(error_report=True)`. Create an issue in the PyTorch GitHub repository against the *onnx* component. Attach the pt2 model and the error report.
E           Error report has been saved to 'onnx_export_2024-06-21_21-40-55-111073_conversion.md'.
```

Refactor the export api.