### PR TITLE
Improve external data name

### DIFF
--- a/src/torch_onnx/_onnx_program.py
+++ b/src/torch_onnx/_onnx_program.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 from typing import IO
 
 import onnx
@@ -26,6 +27,7 @@ class ONNXProgram:
         destination: str | os.PathLike | IO[bytes],
         *,
         include_initializers: bool = True,
+        external_data: bool | None = None,
         **_,
     ):
         if not include_initializers:
@@ -33,12 +35,27 @@ class ONNXProgram:
                 "Developers: Please implement ir.Model copy() and remove initializers"
             )
         proto = ir.serde.serialize_model(self.model)
-        if proto.ByteSize() >= 1 << 31:
+        byte_size = proto.ByteSize()
+        model_too_large = (byte_size) >= 1 << 31
+        if external_data or model_too_large:
             # TODO: Create an IR pass to handle external tensors conversion
-            logger.warning(
-                "The serialized ONNX model is larger than 2GB. "
-                "Saving the weights in a separate file"
+            if model_too_large:
+                logger.warning(
+                    "The serialized ONNX model is larger than 2GB (%s). "
+                    "Saving the weights as external data in a separate file.",
+                    byte_size,
+                )
+            if not isinstance(destination, (str, os.PathLike)):
+                raise TypeError(
+                    "Saving the weights as external data is only supported when destination is a file path"
+                )
+            destination_path = pathlib.Path(destination)
+            data_path = destination_path.with_suffix(f"{destination_path.suffix}.data")
+            onnx.save_model(
+                proto,
+                destination,
+                save_as_external_data=True,
+                location=os.fspath(data_path),
             )
-            onnx.save_model(proto, destination, save_as_external_data=True)
         else:
             onnx.save_model(proto, destination)

--- a/src/torch_onnx/_onnx_program.py
+++ b/src/torch_onnx/_onnx_program.py
@@ -31,8 +31,10 @@ class ONNXProgram:
         **_,
     ):
         if not include_initializers:
-            raise NotImplementedError(
-                "Developers: Please implement ir.Model copy() and remove initializers"
+            self.model.graph.initializers.clear()
+            logger.warning(
+                "The initializers have been removed from the model. This is destructive. "
+                "Developers: Please implement ir.Model copy() and remove initializers on the copied model."
             )
         proto = ir.serde.serialize_model(self.model)
         byte_size = proto.ByteSize()

--- a/src/torch_onnx/_onnx_program.py
+++ b/src/torch_onnx/_onnx_program.py
@@ -30,6 +30,19 @@ class ONNXProgram:
         external_data: bool | None = None,
         **_,
     ):
+        """Save the ONNX model to the specified destination.
+
+        When `external_data` is `True` or the model is larger than 2GB,
+        the weights are saved as external data in a separate file.
+
+        Args:
+            destination: The path to save the ONNX model to.
+            include_initializers: Whether to include the initializers in the saved model.
+            external_data: Whether to save the weights as external data in a separate file.
+
+        Raises:
+            TypeError: If `external_data` is `True` and `destination` is not a file path.
+        """
         if not include_initializers:
             self.model.graph.initializers.clear()
             logger.warning(

--- a/src/torch_onnx/_patch.py
+++ b/src/torch_onnx/_patch.py
@@ -142,7 +142,7 @@ def _torch_onnx_export(
     )
 
     if f is not None:
-        onnx_program.save(f)
+        onnx_program.save(f, include_initializers=export_params)
 
     return onnx_program
 


### PR DESCRIPTION
When the model is `model.onnx` we name the external data file as `model.onnx.data`.