### PR TITLE
Support input_names in dynamic_axes

### DIFF
--- a/src/torch_onnx/_patch.py
+++ b/src/torch_onnx/_patch.py
@@ -59,7 +59,6 @@ def _from_dynamic_axes_to_dynamic_shapes(
         raise ValueError(
             f"Number of input names ({len(input_names)}) should not be greater than the number of model inputs ({len(sig.parameters)})"
         )
-    
     input_names_to_model_inputs = {}
     for idx, param_name in enumerate(sig.parameters):
         if idx < len(input_names):

--- a/src/torch_onnx/_patch.py
+++ b/src/torch_onnx/_patch.py
@@ -48,7 +48,7 @@ def _from_dynamic_axes_to_dynamic_shapes(
     """
     # https://github.com/pytorch/pytorch/pull/128371
     if dynamic_axes is None:
-        return None, input_names
+        return None
 
     if input_names is not None:
         sig = _signature(model)
@@ -61,22 +61,22 @@ def _from_dynamic_axes_to_dynamic_shapes(
             for input_name, param_name in zip(input_names, sig.parameters)
         }
 
-    # NOTE: torch.export.export does not support input names assignmen,
+    # NOTE: torch.export.export does not support input names assignment,
     # so we need to map input names to model inputs to create dynamic_shapes
     # for the exported program
-    dynamic_shapesto_exported_program = {}
+    dynamic_shapes_to_exported_program = {}
     for input_name, axes in dynamic_axes.items():
         if input_name not in input_names_to_model_inputs:
             raise ValueError(
-                f"dynamix axe: {input_name} is not found in the input names: {input_names}"
+                f"dynamix axis: {input_name} is not found in the input names: {input_names}"
             )
         model_input_name = input_names_to_model_inputs[input_name]
         if isinstance(axes, dict):
-            dynamic_shapesto_exported_program[model_input_name] = {
+            dynamic_shapes_to_exported_program[model_input_name] = {
                 k: torch.export.Dim(v) for k, v in axes.items()
             }
         elif isinstance(axes, list):
-            dynamic_shapesto_exported_program[model_input_name] = {
+            dynamic_shapes_to_exported_program[model_input_name] = {
                 k: torch.export.Dim(f"{model_input_name}_dim_{k}") for k in axes
             }
         else:
@@ -86,10 +86,10 @@ def _from_dynamic_axes_to_dynamic_shapes(
     # torch.export.export needs static dim to present in dynamic_shapes
     # for all input tensors, so we need to add them with None
     for input_name in sig.parameters:
-        if input_name not in dynamic_shapesto_exported_program:
-            dynamic_shapesto_exported_program[input_name] = None
+        if input_name not in dynamic_shapes_to_exported_program:
+            dynamic_shapes_to_exported_program[input_name] = None
 
-    return dynamic_shapesto_exported_program
+    return dynamic_shapes_to_exported_program
 
 
 def _get_torch_export_args(

--- a/src/torch_onnx/_patch.py
+++ b/src/torch_onnx/_patch.py
@@ -47,8 +47,7 @@ def _from_dynamic_axes_to_dynamic_shapes(
 
     """
     # https://github.com/pytorch/pytorch/pull/128371
-    
-    # 1. The function does not need to provide dynamic_shapes to torch.export.export 
+    # 1. The function does not need to provide dynamic_shapes to torch.export.export
     if dynamic_axes is None:
         return None
 


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/129276

Tested with
```python
    def test_input_names_are_not_yet_supported_in_dynamic_axes(self):
        import torch_onnx
        torch_onnx.patch_torch(error_report=True, profile=True)
        
        a = torch.onnx.export(
            SampleModelForDynamicShapes(),
            (
                torch.randn(2, 2, 3),
                torch.randn(2, 2, 3),
            ),
            input_names=["input"],
            dynamic_axes={"input": [0, 1]},
            dynamo=True,
        )
        a.save("test.onnx")
```
![Screenshot 2024-07-05 111822](https://github.com/justinchuby/torch-onnx/assets/18010845/739a73ac-b4e4-4925-9e69-30bbf2cf532e)
