### PR TITLE
Import pkg.onnxscript.torch_lib.common

### DIFF
--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -961,6 +961,9 @@ def export(
         if output_names:
             _ir_passes.rename_outputs(ir_model, output_names)
 
+        # TODO(justinchuby): Remove the hack
+        _ir_passes.add_torchlib_common_imports(ir_model)
+
         onnx_program = _onnx_program.ONNXProgram(ir_model, program)
         print("Translate the graph into ONNX... ✅")
 

--- a/src/torch_onnx/_ir_passes.py
+++ b/src/torch_onnx/_ir_passes.py
@@ -16,3 +16,11 @@ def rename_outputs(model: ir.Model, new_names: Sequence[str]):
     for output, new_name in zip(model.graph.outputs, new_names):
         output.metadata_props["pkg.torch.onnx.original_node_name"] = output.name
         output.name = new_name
+
+
+def add_torchlib_common_imports(model: ir.Model):
+    """Hack to add torchlib common imports to the model."""
+
+    # TODO(justinchuby): Remove this hack and improved onnxscript
+
+    model.opset_imports["pkg.onnxscript.torch_lib.common"] = 1

--- a/src/torch_onnx/_ir_passes.py
+++ b/src/torch_onnx/_ir_passes.py
@@ -5,22 +5,21 @@ from typing import Sequence
 from onnxscript import ir
 
 
-def rename_inputs(model: ir.Model, new_names: Sequence[str]):
+def rename_inputs(model: ir.Model, new_names: Sequence[str]) -> None:
     # TODO: Ensure the names do not have duplicates
     for input, new_name in zip(model.graph.inputs, new_names):
         input.metadata_props["pkg.torch.onnx.original_node_name"] = input.name
         input.name = new_name
 
 
-def rename_outputs(model: ir.Model, new_names: Sequence[str]):
+def rename_outputs(model: ir.Model, new_names: Sequence[str]) -> None:
     for output, new_name in zip(model.graph.outputs, new_names):
         output.metadata_props["pkg.torch.onnx.original_node_name"] = output.name
         output.name = new_name
 
 
-def add_torchlib_common_imports(model: ir.Model):
+def add_torchlib_common_imports(model: ir.Model) -> None:
     """Hack to add torchlib common imports to the model."""
 
     # TODO(justinchuby): Remove this hack and improved onnxscript
-
     model.opset_imports["pkg.onnxscript.torch_lib.common"] = 1


### PR DESCRIPTION
Create a hack to add torchlib common imports to the model. This should be removed in the future and we should improve onnxscript to expose all used domains instead.