### PR TITLE
Display detailed error messages from the stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 
 *.onnx
+.DS_Store

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -626,7 +626,7 @@ def _summarize_exception_stack(e: BaseException) -> str:
         e = e.__cause__
     return (
         "\n\n## Exception summary\n\n"
-        + "⬇️\n".join([f"{type(e)}: {e}\n" for e in reversed(causes)])
+        + "⬆️\n".join([f"{type(e)}: {e}\n" for e in reversed(causes)])
         + "\n(Refer to the full stack trace above for more information.)"
     )
 

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -961,8 +961,12 @@ def export(
     if dump_exported_program:
         print("Dumping ExportedProgram because `dump_exported_program=True`...")
         program_path = f"onnx_export_{timestamp}.pt2"
-        torch.export.save(program, program_path)
-        print(f"ExportedProgram has been saved to '{program_path}'.")
+        try:
+            torch.export.save(program, program_path)
+        except Exception as e:
+            print(f"Failed to save ExportedProgram due to an error: {e}")
+        else:
+            print(f"ExportedProgram has been saved to '{program_path}'.")
 
     # Step 2: Convert the exported program to an ONNX model
     try:

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -618,6 +618,19 @@ def _format_exception(e: Exception) -> str:
     return "\n".join(traceback.format_exception(type(e), e, e.__traceback__))
 
 
+def _summarize_exception_stack(e: BaseException) -> str:
+    """Format the exception stack by showing the text of each exception."""
+    causes = []
+    while e.__cause__ is not None:
+        causes.append(e.__cause__)
+        e = e.__cause__
+    return (
+        "\n\n## Exception summary\n"
+        + "\n⬇️\n".join([str(e) for e in causes])
+        + "\nRefer to the full stack trace for more information."
+    )
+
+
 def exported_program_to_ir(
     exported_program: torch.export.ExportedProgram,
     *,
@@ -882,7 +895,7 @@ def export(
                     """)
                 + f"Error report has been saved to '{error_report_path}'."
                 if error_report
-                else ""
+                else "" + _summarize_exception_stack(e)
             ) from e
     else:
         model_repr = _take_first_line(repr(model))
@@ -942,7 +955,7 @@ def export(
                         """)
                     + f"Error report has been saved to '{error_report_path}'."
                     if error_report
-                    else ""
+                    else "" + _summarize_exception_stack(e_export)
                 ) from e_export
 
     if dump_exported_program:
@@ -995,7 +1008,7 @@ def export(
                 """)
             + f"Error report has been saved to '{error_report_path}'."
             if error_report
-            else ""
+            else "" + _summarize_exception_stack(e)
         ) from e
 
     profile_result = _maybe_stop_profiler_and_get_result(profiler)

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -620,14 +620,14 @@ def _format_exception(e: Exception) -> str:
 
 def _summarize_exception_stack(e: BaseException) -> str:
     """Format the exception stack by showing the text of each exception."""
-    causes = []
+    causes = [e]
     while e.__cause__ is not None:
         causes.append(e.__cause__)
         e = e.__cause__
     return (
-        "\n\n## Exception summary\n"
-        + "\n⬇️\n".join([str(e) for e in causes])
-        + "\nRefer to the full stack trace for more information."
+        "\n\n## Exception summary\n\n"
+        + "⬇️\n".join([f"{type(e)}: {e}\n" for e in reversed(causes)])
+        + "\n(Refer to the full stack trace above for more information.)"
     )
 
 
@@ -891,11 +891,13 @@ def export(
             raise errors.TorchScriptConverterError(
                 textwrap.dedent(f"""\
                     Failed to export the model with TorchScript converter. {_BLUE}This is step 1/2{_END} of exporting the model to ONNX. Next steps:
-                    - Create an issue in the PyTorch GitHub repository against the {_BLUE}*torch.export*{_END} component and attach the full error stack as well as reproduction scripts.
-                    """)
-                + f"Error report has been saved to '{error_report_path}'."
-                if error_report
-                else "" + _summarize_exception_stack(e)
+                    - Create an issue in the PyTorch GitHub repository against the {_BLUE}*torch.export*{_END} component and attach the full error stack as well as reproduction scripts.""")
+                + (
+                    f"\nError report has been saved to '{error_report_path}'."
+                    if error_report
+                    else ""
+                )
+                + _summarize_exception_stack(e)
             ) from e
     else:
         model_repr = _take_first_line(repr(model))
@@ -951,11 +953,13 @@ def export(
                         Failed to export the model with torch.export. {_BLUE}This is step 1/2{_END} of exporting the model to ONNX. Next steps:
                         - Modify the model code for `torch.export.export` to succeed. Refer to https://pytorch.org/docs/stable/generated/exportdb/index.html for more information.
                         - Debug `torch.export.export` and summit a PR to PyTorch.
-                        - Create an issue in the PyTorch GitHub repository against the {_BLUE}*torch.export*{_END} component and attach the full error stack as well as reproduction scripts.
-                        """)
-                    + f"Error report has been saved to '{error_report_path}'."
-                    if error_report
-                    else "" + _summarize_exception_stack(e_export)
+                        - Create an issue in the PyTorch GitHub repository against the {_BLUE}*torch.export*{_END} component and attach the full error stack as well as reproduction scripts.""")
+                    + (
+                        f"\nError report has been saved to '{error_report_path}'."
+                        if error_report
+                        else ""
+                    )
+                    + _summarize_exception_stack(e_export)
                 ) from e_export
 
     if dump_exported_program:
@@ -1008,11 +1012,13 @@ def export(
                 Failed to convert the exported program to an ONNX model. {_BLUE}This is step 2/2{_END} of exporting the model to ONNX. Next steps:
                 - If there is a missing ONNX function, implement it and register it to the registry.
                 - If there is an internal error during ONNX conversion, debug the error and summit a PR to PyTorch.
-                - Save the ExportedProgram as a pt2 file and create an error report with `export(error_report=True)`. Create an issue in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component. Attach the pt2 model and the error report.
-                """)
-            + f"Error report has been saved to '{error_report_path}'."
-            if error_report
-            else "" + _summarize_exception_stack(e)
+                - Save the ExportedProgram as a pt2 file and create an error report with `export(error_report=True)`. Create an issue in the PyTorch GitHub repository against the {_BLUE}*onnx*{_END} component. Attach the pt2 model and the error report.""")
+            + (
+                f"\nError report has been saved to '{error_report_path}'."
+                if error_report
+                else ""
+            )
+            + _summarize_exception_stack(e)
         ) from e
 
     profile_result = _maybe_stop_profiler_and_get_result(profiler)

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -841,7 +841,7 @@ def export(
     if error_report or profile or dump_exported_program:
         artifacts_dir.mkdir(parents=True, exist_ok=True)
 
-    # Step 0: Export the model with torch.export.export if the model is not already an ExportedProgram
+    # Step 1: Export the model with torch.export.export if the model is not already an ExportedProgram
     if isinstance(model, torch.export.ExportedProgram):
         program = model
     elif isinstance(model, (torch.jit.ScriptModule, torch.jit.ScriptFunction)):
@@ -951,7 +951,7 @@ def export(
         torch.export.save(program, program_path)
         print(f"ExportedProgram has been saved to '{program_path}'.")
 
-    # Step 1: Convert the exported program to an ONNX model
+    # Step 2: Convert the exported program to an ONNX model
     try:
         print("Translate the graph into ONNX...")
         ir_model = exported_program_to_ir(program, registry=registry)
@@ -1000,12 +1000,6 @@ def export(
 
     profile_result = _maybe_stop_profiler_and_get_result(profiler)
 
-    if dump_exported_program:
-        program_path = artifacts_dir / f"onnx_export_{timestamp}.pt2"
-        print("Dumping ExportedProgram because `dump_exported_program=True`...")
-        torch.export.save(program, program_path)
-        print(f"ExportedProgram has been saved to '{program_path}'.")
-
     if not error_report:
         # Return if error report is not requested
         if profile:
@@ -1018,7 +1012,7 @@ def export(
             )
         return onnx_program
 
-    # Step 2: (When error report is requested) Check the ONNX model with ONNX checker
+    # Step 3: (When error report is requested) Check the ONNX model with ONNX checker
     try:
         print("Run `onnx.checker` on the ONNX model...")
 
@@ -1057,7 +1051,7 @@ def export(
         )
         return onnx_program
 
-    # Step 3: (When error report is requested) Execute the model with ONNX Runtime
+    # Step 4: (When error report is requested) Execute the model with ONNX Runtime
     # try:
     #     print("Execute the model with ONNX Runtime... ")
     #     print("✅")
@@ -1069,7 +1063,7 @@ def export(
     #         "attach the full error stack as well as reproduction scripts. "
     #     ) from e
 
-    # Step 4: (When error report is requested) Validate the output values
+    # Step 5: (When error report is requested) Validate the output values
     # TODO
 
     if profile:


### PR DESCRIPTION
torch_onnx.errors.OnnxConversionError: Failed to convert the exported program to an ONNX model. This is step 2/2 of exporting the model to ONNX. Next steps:
- If there is a missing ONNX function, implement it and register it to the registry.
- If there is an internal error during ONNX conversion, debug the error and summit a PR to PyTorch.
- Save the ExportedProgram as a pt2 file and create an error report with `export(error_report=True)`. Create an issue in the PyTorch GitHub repository against the *onnx* component. Attach the pt2 model and the error report.

## Exception summary

<class 'torch_onnx.errors.DispatchError'>: No ONNX function found for <OpOverload(op='aten.index', overload='Tensor')>. Failure message: No decompositions registered for the complex-valued input
⬆️
<class 'torch_onnx.errors.OnnxConversionError'>: Error when translating node %index : [num_users=1] = call_function[target=torch.ops.aten.index.Tensor](args = (%arg0_1, [%lift_fresh_copy, %lift_fresh_copy_1, %arg7_1]), kwargs = {}). See the stack trace for more information.

(Refer to the full stack trace above for more information.)