### PR TITLE
Set external_data to true

### DIFF
--- a/src/torch_onnx/_onnx_program.py
+++ b/src/torch_onnx/_onnx_program.py
@@ -31,6 +31,7 @@ class ONNXProgram:
         *,
         include_initializers: bool = True,
         external_data: bool | None = None,
+        all_tensors_to_one_file: bool = True,
         **_,
     ):
         """Save the ONNX model to the specified destination.
@@ -42,6 +43,7 @@ class ONNXProgram:
             destination: The path to save the ONNX model to.
             include_initializers: Whether to include the initializers in the saved model.
             external_data: Whether to save the weights as external data in a separate file.
+            all_tensors_to_one_file: Whether to save all tensors to one file when saving as external data.
 
         Raises:
             TypeError: If `external_data` is `True` and `destination` is not a file path.
@@ -74,6 +76,7 @@ class ONNXProgram:
                 proto,
                 destination,
                 save_as_external_data=True,
+                all_tensors_to_one_file=all_tensors_to_one_file,
                 location=data_path,
             )
         else:

--- a/src/torch_onnx/_patch.py
+++ b/src/torch_onnx/_patch.py
@@ -123,6 +123,8 @@ def _torch_onnx_export(
     | Mapping[str, Sequence[int]]
     | None = None,
     dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any] | None = None,
+    external_data: bool = True,
+    all_tensors_to_one_file: bool = True,
     profile: bool = False,
     error_report: bool = False,
     dump_exported_program: bool = False,
@@ -161,7 +163,13 @@ def _torch_onnx_export(
     )
 
     if f is not None:
-        onnx_program.save(f, include_initializers=export_params)
+        # Always save the initializers as external data to reduce the size of the ONNX file
+        onnx_program.save(
+            f,
+            include_initializers=export_params,
+            external_data=external_data,
+            all_tensors_to_one_file=all_tensors_to_one_file,
+        )
 
     return onnx_program
 


### PR DESCRIPTION
Always save the initializers as external data to reduce the size of the ONNX file