### PR TITLE
Fix the way we call decomp

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -26,7 +26,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.4.4',
+    'ruff==0.5.5',
 ]
 is_formatter = true
 
@@ -55,7 +55,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.4.4',
+    'ruff==0.5.5',
 ]
 is_formatter = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ ignore = [
   "E501", # line too long
   "PYI041",
   "NPY002",
+  "SIM103",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/torch_onnx/_building.py
+++ b/src/torch_onnx/_building.py
@@ -445,7 +445,7 @@ class OpRecorder(evaluator.Evaluator):
                     else:
                         # Fall to call add_function_call
                         pass
-                elif isinstance(args[0], Sequence):  # noqa: SIM103
+                elif isinstance(args[0], Sequence):
                     return False
                 else:
                     # Python constants are scalars

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -722,8 +722,9 @@ def _exported_program_to_onnx_program(
     # 1. Add all nodes to the graph and create a dictionary of values
     if lower != "none":
         # Decompose the graph given the implemented torch ops in ONNX
-        decomp_table = _decomp.create_onnx_friendly_decomposition_table(registry)
-        exported_program = exported_program.run_decompositions(decomp_table)
+        exported_program = _fx_passes.decompose_with_registry(
+            exported_program, registry
+        )
 
         graph_module = exported_program.graph_module
         # Include explicit type promotion nodes

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -656,6 +656,33 @@ def exported_program_to_ir(
             none: Do not lower the graph.
         registry: The registry of all ONNX Script decomposition.
     """
+    return _exported_program_to_onnx_program(
+        exported_program, registry=registry, lower=lower
+    ).model
+
+
+def _exported_program_to_onnx_program(
+    exported_program: torch.export.ExportedProgram,
+    *,
+    registry: _registration.OnnxRegistry | None = None,
+    lower: Literal["at_conversion", "post_conversion", "none"] = "at_conversion",
+) -> _onnx_program.ONNXProgram:
+    """Convert an exported program to an ONNX Program.
+
+    The exported_program field in the returned ONNXProgram is one that is after
+    decompositions have been applied.
+
+    Reference:
+        - ExportedProgram spec: https://pytorch.org/docs/stable/export.ir_spec.html
+
+    Args:
+        exported_program: The exported program to convert.
+        lower: Whether to lower the graph to core ONNX operators.
+            at_conversion: Lower whe translating the FX graph to ONNX IR.
+            post_conversion: Use an IR pass to lower the graph.
+            none: Do not lower the graph.
+        registry: The registry of all ONNX Script decomposition.
+    """
     if registry is None:
         # Trigger op registration
         from onnxscript.function_libs.torch_lib import ops
@@ -696,11 +723,15 @@ def exported_program_to_ir(
     if lower != "none":
         # Decompose the graph given the implemented torch ops in ONNX
         decomp_table = _decomp.create_onnx_friendly_decomposition_table(registry)
-        exported_program.run_decompositions(decomp_table)
+        exported_program = exported_program.run_decompositions(decomp_table)
 
+        graph_module = exported_program.graph_module
         # Include explicit type promotion nodes
-        _fx_passes.insert_type_promotion_nodes(exported_program)
-        _fx_passes.remove_assertion_nodes(exported_program)
+        graph_module = _fx_passes.insert_type_promotion_nodes(graph_module)
+        graph_module = _fx_passes.remove_assertion_nodes(graph_module)
+        # TODO(justinchuby): Reassigning the graph module to save some runtime.
+        # If this does not work, we need to retrace the module with torch.export
+        exported_program._graph_module = graph_module
     values = _add_nodes(exported_program, model, lower=lower, registry=registry)
 
     # 2. Add user inputs and all parameters/buffers to the graph.
@@ -826,16 +857,7 @@ def exported_program_to_ir(
 
     # TODO: Decide if we should keep mutated buffers as inputs/outputs
 
-    return model
-
-
-def _take_first_line(text: str) -> str:
-    """Take the first line of a text."""
-    lines = text.split("\n", maxsplit=1)
-    first_line = lines[0]
-    if len(lines) > 1:
-        first_line += "[...]"
-    return first_line
+    return _onnx_program.ONNXProgram(model, exported_program)
 
 
 def _verbose_printer(verbose: bool | None) -> Callable[..., None]:
@@ -985,17 +1007,16 @@ def export(
     # Step 2: Convert the exported program to an ONNX model
     try:
         verbose_print("Translate the graph into ONNX...")
-        ir_model = exported_program_to_ir(program, registry=registry)
+        onnx_program = _exported_program_to_onnx_program(program, registry=registry)
 
         if input_names:
-            _ir_passes.rename_inputs(ir_model, input_names)
+            _ir_passes.rename_inputs(onnx_program.model, input_names)
         if output_names:
-            _ir_passes.rename_outputs(ir_model, output_names)
+            _ir_passes.rename_outputs(onnx_program.model, output_names)
 
         # TODO(justinchuby): Remove the hack
-        _ir_passes.add_torchlib_common_imports(ir_model)
+        _ir_passes.add_torchlib_common_imports(onnx_program.model)
 
-        onnx_program = _onnx_program.ONNXProgram(ir_model, program)
         export_status.onnx_translation = True
         verbose_print("Translate the graph into ONNX... ✅")
 

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -29,7 +29,6 @@ from torch.export import graph_signature
 from torch_onnx import (
     _building,
     _capture_strategies,
-    _decomp,
     _dispatching,
     _fx_passes,
     _ir_passes,

--- a/src/torch_onnx/_dispatching.py
+++ b/src/torch_onnx/_dispatching.py
@@ -192,8 +192,8 @@ def _get_named_fx_node_args(node: torch.fx.Node) -> dict[str, torch.fx.node.Argu
     node_args = {}
     for arg, schema_arg in zip(node.args, torch_schema.arguments):
         node_args[schema_arg.name] = arg
-    for name, arg in node.kwargs.items():
-        node_args[name] = arg
+
+    node_args.update(node.kwargs)
     return node_args
 
 

--- a/src/torch_onnx/_fx_passes.py
+++ b/src/torch_onnx/_fx_passes.py
@@ -5,12 +5,25 @@ import torch.export
 from torch.onnx._internal.fx import diagnostics, passes
 import torch.fx
 
+from torch_onnx import _decomp, _registration
+
 _ATEN_ASSERTION_TARGETS = frozenset(
     {
         torch.ops.aten.sym_constrain_range_for_size.default,
         torch.ops.aten._assert_async.msg,
     }
 )
+
+
+def decompose_with_registry(
+    exported_program: torch.export.ExportedProgram, registry: _registration.OnnxRegistry
+) -> torch.export.ExportedProgram:
+    """Decompose the exported program with the given registry.
+
+    This function is needed so it shows clearly on the profiler results.
+    """
+    decomp_table = _decomp.create_onnx_friendly_decomposition_table(registry)
+    return exported_program.run_decompositions(decomp_table)
 
 
 def insert_type_promotion_nodes(

--- a/src/torch_onnx/_registration.py
+++ b/src/torch_onnx/_registration.py
@@ -135,7 +135,7 @@ class OnnxRegistry:
         cls,
         torchlib_registry: Mapping[str, torchlib_registration.OverloadedFunction]
         | None = None,
-    ):
+    ) -> OnnxRegistry:
         """Populates the registry with ATen functions from torchlib.
 
         Args:

--- a/tests/decomp_test.py
+++ b/tests/decomp_test.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import unittest
+import torch
+import torch._decomp
+
+
+class DecompTest(unittest.TestCase):
+    def test_decomp(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.adaptive_avg_pool2d(x, [3, 3])
+
+        exported_program = torch.export.export(Model(), (torch.rand(1, 3, 16, 16),))
+        print("Before decomposition:")
+        print(exported_program)
+        decomposed = exported_program.run_decompositions(
+            {
+                torch.ops.aten._adaptive_avg_pool2d: torch._decomp.decompositions.adaptive_avg_pool2d,
+                torch.ops.aten.adaptive_avg_pool2d: torch._decomp.decompositions.adaptive_avg_pool2d,
+            }
+        )
+        print("After decomposition:")
+        print(decomposed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/decomp_test.py
+++ b/tests/decomp_test.py
@@ -3,25 +3,34 @@ from __future__ import annotations
 import unittest
 import torch
 import torch._decomp
+import torch_onnx
+
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        return torch.ops.aten.adaptive_avg_pool2d(x, [3, 3])
 
 
 class DecompTest(unittest.TestCase):
     def test_decomp(self):
-        class Model(torch.nn.Module):
-            def forward(self, x):
-                return torch.ops.aten.adaptive_avg_pool2d(x, [3, 3])
-
         exported_program = torch.export.export(Model(), (torch.rand(1, 3, 16, 16),))
         print("Before decomposition:")
         print(exported_program)
+        # NOTE: It is important to include the `default` in keys
         decomposed = exported_program.run_decompositions(
             {
-                torch.ops.aten._adaptive_avg_pool2d: torch._decomp.decompositions.adaptive_avg_pool2d,
-                torch.ops.aten.adaptive_avg_pool2d: torch._decomp.decompositions.adaptive_avg_pool2d,
+                torch.ops.aten._adaptive_avg_pool2d.default: torch._decomp.decompositions.adaptive_avg_pool2d,
+                torch.ops.aten.adaptive_avg_pool2d.default: torch._decomp.decompositions.adaptive_avg_pool2d,
             }
         )
         print("After decomposition:")
         print(decomposed)
+
+    def test_export(self):
+        model = Model()
+        input = torch.rand(1, 3, 16, 16)
+        onnx_program = torch_onnx.export(model, (input,))
+        print(onnx_program.exported_program)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously `run_decomposition` was called but the result was not used because I thought the operation was in place. This change fixes its usage.