### PR TITLE
Update error reporting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ onnx.save(proto, "model.onnx")
 
 # Or patch the torch.onnx export API
 # Set error_report=True to get a detailed error report if the export fails
-torch_onnx.patch_torch(error_report=True, profile=True)
+torch_onnx.patch_torch(report=True, verify=True, profile=True)
 torch.onnx.export(...)
 
 # Use the analysis API to print an analysis report for unsupported ops

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -904,9 +904,9 @@ def export(
     dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any] | None = None,
     input_names: Sequence[str] | None = None,
     output_names: Sequence[str] | None = None,
-    profile: bool = False,
     report: bool = False,
     verify: bool = False,
+    profile: bool = False,
     dump_exported_program: bool = False,
     artifacts_dir: str | os.PathLike = ".",
     verbose: bool | None = None,
@@ -921,9 +921,11 @@ def export(
         dynamic_shapes: Dynamic shapes in the graph.
         input_names: If provided, rename the inputs.
         output_names: If provided, rename the outputs.
-        profile: Whether to profile the export process.
         report: Whether to generate an error report if the export fails.
         verify: Whether to verify the ONNX model after exporting.
+        profile: Whether to profile the export process. When report is True,
+            the profile result will be saved in the report. Otherwise, the profile
+            result will be printed.
         dump_exported_program: Whether to save the exported program to a file.
         artifacts_dir: The directory to save the exported program and error reports.
         verbose: Whether to print verbose messages. If None (default), some messages will be printed.
@@ -1146,9 +1148,8 @@ def export(
 
     if not verify:
         # Return if verification is not requested
-        if profile:
+        if report:
             try:
-                assert profile_result is not None
                 assert pre_decomp_unique_ops is not None
                 assert post_decomp_unique_ops is not None
                 _reporting.create_onnx_export_report(
@@ -1167,6 +1168,9 @@ def export(
                 verbose_print(
                     f"Failed to save profile report due to an error: {e_report}"
                 )
+        elif profile and profile_result is not None:
+            verbose_print("Profile result:")
+            verbose_print(profile_result)
         return onnx_program
 
     # Step 3: (When error report is requested) Check the ONNX model with ONNX checker

--- a/src/torch_onnx/_patch.py
+++ b/src/torch_onnx/_patch.py
@@ -17,8 +17,8 @@ from torch_onnx import _onnx_program, _core
 
 logger = logging.getLogger(__name__)
 
-WRITE_ERROR_REPORT = False
-WRITE_PROFILE_REPORT = False
+WRITE_REPORT = False
+PROFILE_EXECUTION = False
 DUMP_EXPORTED_PROGRAM = False
 ARTIFACTS_DIR = "."
 
@@ -125,15 +125,15 @@ def _torch_onnx_export(
     dynamic_shapes: dict[str, Any] | tuple[Any, ...] | list[Any] | None = None,
     external_data: bool = True,
     all_tensors_to_one_file: bool = True,
+    report: bool = False,
     profile: bool = False,
-    error_report: bool = False,
     dump_exported_program: bool = False,
     artifacts_dir: str | os.PathLike = ".",
     **_,
 ) -> _onnx_program.ONNXProgram:
     # Set up the error reporting facilities
-    error_report = WRITE_ERROR_REPORT or error_report
-    profile = WRITE_PROFILE_REPORT or profile
+    report = WRITE_REPORT or report
+    profile = PROFILE_EXECUTION or profile
     dump_exported_program = DUMP_EXPORTED_PROGRAM or dump_exported_program
     artifacts_dir = ARTIFACTS_DIR if artifacts_dir == "." else artifacts_dir
 
@@ -157,7 +157,8 @@ def _torch_onnx_export(
         input_names=input_names,
         output_names=output_names,
         profile=profile,
-        error_report=error_report,
+        report=report,
+        verify=report,
         dump_exported_program=dump_exported_program,
         artifacts_dir=artifacts_dir,
     )
@@ -188,8 +189,9 @@ def _torch_onnx_dynamo_export(
         model,
         model_args,
         kwargs=model_kwargs,
-        error_report=WRITE_ERROR_REPORT,
-        profile=WRITE_PROFILE_REPORT,
+        report=WRITE_REPORT,
+        verify=WRITE_REPORT,
+        profile=PROFILE_EXECUTION,
         dump_exported_program=DUMP_EXPORTED_PROGRAM,
         artifacts_dir=ARTIFACTS_DIR,
     )
@@ -201,16 +203,25 @@ _original_torch_onnx_dynamo_export = torch.onnx.dynamo_export
 
 
 def patch_torch(
+    *,
+    report: bool = False,
     error_report: bool = False,
     profile: bool = False,
     dump_exported_program: bool = False,
     artifacts_dir: str | os.PathLike = ".",
     **_,
 ):
-    global WRITE_ERROR_REPORT  # noqa: PLW0603
-    WRITE_ERROR_REPORT = error_report
-    global WRITE_PROFILE_REPORT  # noqa: PLW0603
-    WRITE_PROFILE_REPORT = profile
+    if error_report:
+        warnings.warn(
+            "The 'error_report' argument is deprecated. Please use 'report' instead.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+        report = error_report
+    global WRITE_REPORT  # noqa: PLW0603
+    WRITE_REPORT = report
+    global PROFILE_EXECUTION  # noqa: PLW0603
+    PROFILE_EXECUTION = profile
     global DUMP_EXPORTED_PROGRAM  # noqa: PLW0603
     DUMP_EXPORTED_PROGRAM = dump_exported_program
     global ARTIFACTS_DIR  # noqa: PLW0603

--- a/src/torch_onnx/_patch.py
+++ b/src/torch_onnx/_patch.py
@@ -126,6 +126,7 @@ def _torch_onnx_export(
     external_data: bool = True,
     all_tensors_to_one_file: bool = True,
     report: bool = False,
+    verify: bool = False,
     profile: bool = False,
     dump_exported_program: bool = False,
     artifacts_dir: str | os.PathLike = ".",
@@ -133,6 +134,7 @@ def _torch_onnx_export(
 ) -> _onnx_program.ONNXProgram:
     # Set up the error reporting facilities
     report = WRITE_REPORT or report
+    verify = WRITE_REPORT or verify
     profile = PROFILE_EXECUTION or profile
     dump_exported_program = DUMP_EXPORTED_PROGRAM or dump_exported_program
     artifacts_dir = ARTIFACTS_DIR if artifacts_dir == "." else artifacts_dir
@@ -158,7 +160,7 @@ def _torch_onnx_export(
         output_names=output_names,
         profile=profile,
         report=report,
-        verify=report,
+        verify=verify,
         dump_exported_program=dump_exported_program,
         artifacts_dir=artifacts_dir,
     )
@@ -205,7 +207,7 @@ _original_torch_onnx_dynamo_export = torch.onnx.dynamo_export
 def patch_torch(
     *,
     report: bool = False,
-    error_report: bool = False,
+    error_report: bool = False,  # deprecated
     profile: bool = False,
     dump_exported_program: bool = False,
     artifacts_dir: str | os.PathLike = ".",

--- a/src/torch_onnx/bin/convert.py
+++ b/src/torch_onnx/bin/convert.py
@@ -14,9 +14,9 @@ def _parse_args():
         "--external_data", type=bool, help="Save the weights in a separate file."
     )
     parser.add_argument(
-        "--no_error_report",
+        "--report",
         type=bool,
-        help="Do not produce an error report if the conversion fails.",
+        help="Produce a conversion report.",
     )
     args = parser.parse_args()
     return args
@@ -32,9 +32,7 @@ def main():
     from torch_onnx._core import export
 
     exported_program = torch.export.load(args.model_path)
-    onnx_program = export(
-        exported_program, (), {}, error_report=not args.no_error_report
-    )
+    onnx_program = export(exported_program, (), {}, report=args.report)
     del exported_program
     onnx_program.save(args.output_path)
 

--- a/tests/conversion_test.py
+++ b/tests/conversion_test.py
@@ -10,9 +10,7 @@ from functorch.experimental.control_flow import cond
 
 IS_MAIN = __name__ == "__main__"
 
-torch_onnx.patch_torch(
-    error_report=IS_MAIN, profile=IS_MAIN, dump_exported_program=IS_MAIN
-)
+torch_onnx.patch_torch(report=IS_MAIN, profile=IS_MAIN, dump_exported_program=IS_MAIN)
 
 
 class ConversionTest(unittest.TestCase):

--- a/tests/models/longformer_export.py
+++ b/tests/models/longformer_export.py
@@ -2,7 +2,7 @@ import torch
 import torch_onnx
 from transformers import LongformerModel, LongformerTokenizer
 
-torch_onnx.patch_torch(error_report=True, profile=True, dump_exported_program=True)
+torch_onnx.patch_torch(report=True, profile=True, dump_exported_program=True)
 
 tokenizer = LongformerTokenizer.from_pretrained("allenai/longformer-base-4096")
 model = LongformerModel.from_pretrained("allenai/longformer-base-4096")

--- a/tests/models/resnet_export_test.py
+++ b/tests/models/resnet_export_test.py
@@ -9,7 +9,7 @@ from torch_onnx import _verification
 class ResnetTest(unittest.TestCase):
     def test_resnet(self):
         torch_onnx.patch_torch(
-            error_report=True,
+            report=True,
             profile=True,
             dump_exported_program=True,
             artifacts_dir="resnet18",

--- a/tests/quantization_test.py
+++ b/tests/quantization_test.py
@@ -12,9 +12,7 @@ from torch.ao.quantization.quantizer import xnnpack_quantizer
 
 IS_MAIN = __name__ == "__main__"
 
-torch_onnx.patch_torch(
-    error_report=IS_MAIN, profile=IS_MAIN, dump_exported_program=IS_MAIN
-)
+torch_onnx.patch_torch(report=IS_MAIN, profile=IS_MAIN, dump_exported_program=IS_MAIN)
 
 
 class Model(torch.nn.Module):

--- a/tests/torch_tests/fx_consistency_test_.py
+++ b/tests/torch_tests/fx_consistency_test_.py
@@ -67,7 +67,7 @@ from torch.testing._internal.opinfo import core as opinfo_core
 
 import torch_onnx
 
-torch_onnx.patch_torch(error_report=True, profile=False)
+torch_onnx.patch_torch(report=True, profile=False)
 
 
 # NOTE: For ATen signature modifications that will break ONNX export,

--- a/tests/torch_tests/fx_to_onnx_with_onnxruntime_test_.py
+++ b/tests/torch_tests/fx_to_onnx_with_onnxruntime_test_.py
@@ -24,7 +24,7 @@ from torch.testing._internal import common_utils
 
 import torch_onnx
 
-torch_onnx.patch_torch(error_report=True)
+torch_onnx.patch_torch(report=True)
 
 
 def _parameterized_class_attrs_and_values():

--- a/tests/torch_tests/torch_onnx_test_.py
+++ b/tests/torch_tests/torch_onnx_test_.py
@@ -33,7 +33,7 @@ from torch.testing._internal.common_utils import skipIfNoLapack
 
 import torch_onnx
 
-torch_onnx.patch_torch(error_report=True, profile=False)
+torch_onnx.patch_torch(report=True, profile=False)
 
 
 def _init_test_generalized_rcnn_transform():


### PR DESCRIPTION
Change `error_report` to `report` to reflect that we always create a report for failures and successes. Added a `verify` option to run checkers. The `patch` behavior` is kept the same.