### PR TITLE
Persist inference session for ORT

### DIFF
--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -1150,7 +1150,7 @@ def export(
                 assert pre_decomp_unique_ops is not None
                 assert post_decomp_unique_ops is not None
                 _reporting.create_onnx_export_report(
-                    artifacts_dir / f"onnx_export_{timestamp}_profile.md",
+                    artifacts_dir / f"onnx_export_{timestamp}_success.md",
                     "No errors"
                     if not failed_results
                     else _format_exceptions_for_all_strategies(failed_results),

--- a/src/torch_onnx/_onnx_program.py
+++ b/src/torch_onnx/_onnx_program.py
@@ -52,7 +52,11 @@ ONNXProgram(
             k.name: v.numpy(force=True)
             for k, v in zip(self.model.graph.inputs, flatten_args)
         }
-        outputs = self._inference_session.run(None, onnxruntime_input)
+        run_options = ort.RunOptions()
+        run_options.log_severity_level = 3  # 3: Error
+        outputs = self._inference_session.run(
+            None, onnxruntime_input, run_options=run_options
+        )
         return tuple(torch.from_numpy(output) for output in outputs)
 
     @property
@@ -141,8 +145,10 @@ ONNXProgram(
         else:
             model = proto.SerializeToString()
 
+        session_options = ort.SessionOptions()
+        session_options.log_severity_level = 3  # 3: Error
         self._inference_session = ort.InferenceSession(
-            model, providers=("CPUExecutionProvider",)
+            model, providers=("CPUExecutionProvider",), sess_options=session_options
         )
 
     def release(self) -> None:

--- a/src/torch_onnx/_onnx_program.py
+++ b/src/torch_onnx/_onnx_program.py
@@ -40,6 +40,8 @@ ONNXProgram(
 
     def __call__(self, *args, **kwargs) -> Sequence[torch.Tensor]:
         """Run the ONNX model with the same arguments you would provide to the GraphModule."""
+        import onnxruntime as ort
+
         flatten_args = _process_args(args, kwargs)
 
         if self._inference_session is None:


### PR DESCRIPTION
Hold on to the the inference session created if the ONNXProgram is called. Create a `release()` method to allow for manual release.