### PR TITLE
More better inference

### DIFF
--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -1136,6 +1136,7 @@ def export(
                     profile_result=profile_result,
                     registry=registry,
                 )
+                verbose_print(f"Export report has been saved to '{report_path}'.")
             except Exception:
                 logger.exception("Failed to save report due to an error.")
         else:
@@ -1155,9 +1156,11 @@ def export(
             try:
                 assert pre_decomp_unique_ops is not None
                 assert post_decomp_unique_ops is not None
+                report_path = artifacts_dir / _reporting.construct_report_file_name(
+                    timestamp, export_status
+                )
                 _reporting.create_onnx_export_report(
-                    artifacts_dir
-                    / _reporting.construct_report_file_name(timestamp, export_status),
+                    report_path,
                     "No errors"
                     if not failed_results
                     else _format_exceptions_for_all_strategies(failed_results),
@@ -1169,6 +1172,7 @@ def export(
                     ),
                     registry=registry,
                 )
+                verbose_print(f"Export report has been saved to '{report_path}'.")
             except Exception:
                 logger.exception("Failed to save report due to an error.")
         elif profile and profile_result is not None:
@@ -1202,9 +1206,11 @@ def export(
             try:
                 assert pre_decomp_unique_ops is not None
                 assert post_decomp_unique_ops is not None
+                report_path = artifacts_dir / _reporting.construct_report_file_name(
+                    timestamp, export_status
+                )
                 _reporting.create_onnx_export_report(
-                    artifacts_dir
-                    / _reporting.construct_report_file_name(timestamp, export_status),
+                    report_path,
                     f"{_format_exceptions_for_all_strategies(failed_results)}\n\n{_format_exception(e)}",
                     onnx_program.exported_program,
                     decomp_comparison=_reporting.format_decomp_comparison(
@@ -1215,6 +1221,7 @@ def export(
                     model=onnx_program.model,
                     registry=registry,
                 )
+                verbose_print(f"Export report has been saved to '{report_path}'.")
             except Exception:
                 logger.exception("Failed to save report due to an error.")
         logger.warning(
@@ -1283,9 +1290,11 @@ def export(
             if not traceback_lines:
                 traceback_lines.append("No errors")
 
+            report_path = artifacts_dir / _reporting.construct_report_file_name(
+                timestamp, export_status
+            )
             _reporting.create_onnx_export_report(
-                artifacts_dir
-                / _reporting.construct_report_file_name(timestamp, export_status),
+                report_path,
                 "\n\n".join(traceback_lines),
                 onnx_program.exported_program,
                 profile_result=profile_result,
@@ -1297,6 +1306,7 @@ def export(
                 registry=registry,
                 verification_result=verification_message,
             )
+            verbose_print(f"Export report has been saved to '{report_path}'.")
         except Exception:
             logger.exception("Failed to save report due to an error.")
 

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -1273,8 +1273,11 @@ def export(
 
             traceback_lines = []
             if failed_results:
-                traceback_lines.append(_format_exceptions_for_all_strategies(failed_results))
+                traceback_lines.append(
+                    _format_exceptions_for_all_strategies(failed_results)
+                )
             if onnx_runtime_error_message:
+                traceback_lines.append("# ⚠️ ONNX Runtime error -----------------------")
                 traceback_lines.append(onnx_runtime_error_message)
             if not traceback_lines:
                 traceback_lines.append("No errors")

--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -987,7 +987,9 @@ def export(
             profile_result = _maybe_stop_profiler_and_get_result(profiler)
 
             if report:
-                report_path = artifacts_dir / f"onnx_export_{timestamp}_pt_export.md"
+                report_path = artifacts_dir / _reporting.construct_report_file_name(
+                    timestamp, export_status
+                )
 
                 try:
                     _reporting.create_torch_export_error_report(
@@ -1057,7 +1059,9 @@ def export(
         profile_result = _maybe_stop_profiler_and_get_result(profiler)
 
         if report:
-            report_path = artifacts_dir / f"onnx_export_{timestamp}_conversion.md"
+            report_path = artifacts_dir / _reporting.construct_report_file_name(
+                timestamp, export_status
+            )
 
             # Run the analysis to get the error report
             try:
@@ -1112,7 +1116,9 @@ def export(
         profile_result = _maybe_stop_profiler_and_get_result(profiler)
 
         if report:
-            report_path = artifacts_dir / f"onnx_export_{timestamp}_conversion.md"
+            report_path = artifacts_dir / _reporting.construct_report_file_name(
+                timestamp, export_status
+            )
 
             try:
                 assert pre_decomp_unique_ops is not None
@@ -1149,9 +1155,9 @@ def export(
             try:
                 assert pre_decomp_unique_ops is not None
                 assert post_decomp_unique_ops is not None
-                postfix = "strategies" if failed_results else "success"
                 _reporting.create_onnx_export_report(
-                    artifacts_dir / f"onnx_export_{timestamp}_{postfix}.md",
+                    artifacts_dir
+                    / _reporting.construct_report_file_name(timestamp, export_status),
                     "No errors"
                     if not failed_results
                     else _format_exceptions_for_all_strategies(failed_results),
@@ -1197,7 +1203,8 @@ def export(
                 assert pre_decomp_unique_ops is not None
                 assert post_decomp_unique_ops is not None
                 _reporting.create_onnx_export_report(
-                    artifacts_dir / f"onnx_export_{timestamp}_checker.md",
+                    artifacts_dir
+                    / _reporting.construct_report_file_name(timestamp, export_status),
                     f"{_format_exceptions_for_all_strategies(failed_results)}\n\n{_format_exception(e)}",
                     onnx_program.exported_program,
                     decomp_comparison=_reporting.format_decomp_comparison(
@@ -1264,12 +1271,6 @@ def export(
         try:
             assert pre_decomp_unique_ops is not None
             assert post_decomp_unique_ops is not None
-            if export_status.onnx_runtime is False:
-                postfix = "runtime"
-            elif export_status.output_accuracy is False:
-                postfix = "accuracy"
-            else:
-                postfix = "success"
 
             traceback_lines = []
             if failed_results:
@@ -1283,7 +1284,8 @@ def export(
                 traceback_lines.append("No errors")
 
             _reporting.create_onnx_export_report(
-                artifacts_dir / f"onnx_export_{timestamp}_{postfix}.md",
+                artifacts_dir
+                / _reporting.construct_report_file_name(timestamp, export_status),
                 "\n\n".join(traceback_lines),
                 onnx_program.exported_program,
                 profile_result=profile_result,

--- a/src/torch_onnx/_onnx_program.py
+++ b/src/torch_onnx/_onnx_program.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 def _ort_session_initializer(model: str | bytes) -> ort.InferenceSession:
     """Initialize an ONNX Runtime inference session with the specified model."""
+    import onnxruntime as ort
+
     session_options = ort.SessionOptions()
     session_options.log_severity_level = 3  # 3: Error
     possible_providers = (

--- a/src/torch_onnx/_onnx_program.py
+++ b/src/torch_onnx/_onnx_program.py
@@ -58,6 +58,7 @@ ONNXProgram(
         logger.debug("Running the inference session with %s arguments.", len(ort_input))
         outputs = self._inference_session.run(None, ort_input, run_options=run_options)
         logger.debug("Inference session run completed.")
+        # TODO(justinchuby): Maybe output complex tensors as needed
         return tuple(torch.from_numpy(output) for output in outputs)
 
     @property

--- a/src/torch_onnx/_onnx_program.py
+++ b/src/torch_onnx/_onnx_program.py
@@ -50,17 +50,13 @@ ONNXProgram(
         assert self._inference_session is not None
 
         # We don't expect non-tensor as inputs
-        onnxruntime_input = {
+        ort_input = {
             k.name: v.numpy() for k, v in zip(self.model.graph.inputs, flatten_args)
         }
         run_options = ort.RunOptions()
         run_options.log_severity_level = 3  # 3: Error
-        logger.debug(
-            "Running the inference session with %s arguments.", len(onnxruntime_input)
-        )
-        outputs = self._inference_session.run(
-            None, onnxruntime_input, run_options=run_options
-        )
+        logger.debug("Running the inference session with %s arguments.", len(ort_input))
+        outputs = self._inference_session.run(None, ort_input, run_options=run_options)
         logger.debug("Inference session run completed.")
         return tuple(torch.from_numpy(output) for output in outputs)
 

--- a/src/torch_onnx/_reporting.py
+++ b/src/torch_onnx/_reporting.py
@@ -133,7 +133,6 @@ def create_onnx_export_report(
     profile_result: str | None,
     model: ir.Model | None = None,
     registry: _registration.ONNXRegistry | None = None,
-    onnx_runtime_error_message: str | None = None,
     verification_result: str | None = None,
 ):
     with open(filename, "w", encoding="utf-8") as f:
@@ -156,11 +155,6 @@ def create_onnx_export_report(
             f.write("\n## Decomposition comparison\n\n")
             f.write(decomp_comparison)
             f.write("\n")
-        if onnx_runtime_error_message is not None:
-            f.write("\n## ONNX Runtime error message\n\n")
-            f.write("```pytb\n")
-            f.write(onnx_runtime_error_message)
-            f.write("\n```\n")
         if verification_result is not None:
             f.write("\n## Verification results\n\n")
             f.write(verification_result)

--- a/src/torch_onnx/_reporting.py
+++ b/src/torch_onnx/_reporting.py
@@ -66,6 +66,27 @@ def _format_exported_program(exported_program: torch.export.ExportedProgram) -> 
     return text
 
 
+def construct_report_file_name(timestamp: str, status: ExportStatus) -> str:
+    # Status could be None. So we need to check for False explicitly.
+    if not (status.torch_export or status.torch_export_non_strict or status.torch_jit):
+        # All strategies failed
+        postfix = "pt_export"
+    elif status.onnx_translation is False:
+        postfix = "conversion"
+    elif status.onnx_checker is False:
+        postfix = "checker"
+    elif status.onnx_runtime is False:
+        postfix = "runtime"
+    elif status.output_accuracy is False:
+        postfix = "accuracy"
+    elif status.torch_export is False or status.torch_export_non_strict is False:
+        # Some strategies failed
+        postfix = "strategies"
+    else:
+        postfix = "success"
+    return f"onnx_export_{timestamp}_{postfix}.md"
+
+
 def format_decomp_comparison(
     pre_decomp_unique_ops: set[str],
     post_decomp_unique_ops: set[str],


### PR DESCRIPTION
1. Refactor logic for building the report file name into a function
2. Use CUDA in the inference session when available
3. Allow users to provide their own `ort_session_initializer`
4. Combine ORT error traceback with the main error section