### PR TITLE
Revert "Use the CPU execution provider only to ensure comparison consistency"

### DIFF
--- a/src/torch_onnx/_onnx_program.py
+++ b/src/torch_onnx/_onnx_program.py
@@ -27,8 +27,17 @@ def _ort_session_initializer(model: str | bytes) -> ort.InferenceSession:
 
     session_options = ort.SessionOptions()
     session_options.log_severity_level = 3  # 3: Error
-    # Use the CPU execution provider only to ensure comparison consistency
-    providers = ["CPUExecutionProvider"]
+    session_options.graph_optimization_level = (
+        ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+    )
+    possible_providers = (
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    )
+    available_providers = set(ort.get_available_providers())
+    providers = [
+        provider for provider in possible_providers if provider in available_providers
+    ]
     return ort.InferenceSession(
         model, providers=providers, sess_options=session_options
     )


### PR DESCRIPTION
Reverts justinchuby/torch-onnx#137 because cpu is unnecessarily slow