### PR TITLE
Use preserve_ops for decomposition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,13 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["torch>=2.1", "onnxscript>=0.1.0.dev20240621", "onnx>=1.16", "typing-extensions"]
+dependencies = [
+  "torch>=2.1",
+  "onnxscript>=0.1.0.dev20240621",
+  "onnx>=1.16",
+  "typing-extensions",
+  "packaging"
+]
 
 [project.urls]
 Repository = "https://github.com/justinchuby/torch-onnx"

--- a/src/torch_onnx/_decomp.py
+++ b/src/torch_onnx/_decomp.py
@@ -38,9 +38,64 @@ def get_onnx_implemented_overloads(
     return registered_ops
 
 
-def full_decomposition_table() -> dict[torch._ops.OperatorBase, Callable]:
-    """Return the full decomposition table."""
+def create_onnx_friendly_decomposition_table(
+    registry,
+) -> dict[torch._ops.OperatorBase, Callable]:
+    """
+    This function creates a dictionary of op overloads and their decomposition functions
+    for ops that do not have ONNX symbolic functions. If an op already has an ONNX symbolic function,
+    its decomposition function is excluded from the table. The decomposition table is a subset of PyTorch's
+    built-in aten-to-aten decomposition.
+
+    Args:
+        registry: The ONNX registry for PyTorch.
+
+    Returns:
+        Dict[torch._ops.OperatorBase, Callable]: A dictionary that maps op overloads to their corresponding
+        decomposition functions.
+    """
+    decomposition_table: dict[torch._ops.OperatorBase, Callable] = {}
+    onnx_registered_ops = set(get_onnx_implemented_overloads(registry))
+
     # NOTE: If we import torch._decomp, we will get RuntimeError: Only a single
     # TORCH_LIBRARY can be used to register the namespace nvprims; please put all of your
     # definitions in a single TORCH_LIBRARY block.
-    return torch._decomp.decomposition_table
+    for op_overload, decomp_fn in torch._decomp.decomposition_table.items():  # type: ignore[attr-defined]
+        # Skip decomposition for op_overload as long as that op_overload has a corresponding ONNX
+        # symbolic function.
+        # NOTE: Do not skip torch._refs decomps. They are fine because otherwise the model is
+        # not exportable anyways.
+        if op_overload in onnx_registered_ops:
+            continue
+        decomposition_table[op_overload] = decomp_fn
+
+    return decomposition_table
+
+
+def valid_to_preserve(op_overload: torch._ops.OperatorBase) -> bool:
+    # Adapted from https://github.com/pytorch/pytorch/blob/611c1043709dc04ed500c551aeb40f69e56a1a4f/torch/export/exported_program.py#L177
+    # PyTorch License
+    # TODO(justinchuby): Update when the source changes
+    from torch._subclasses.functional_tensor import FunctionalTensor
+
+    if op_overload in FunctionalTensor.maybe_aliasing_or_mutating_ops:
+        return False
+    if op_overload in FunctionalTensor.metadata_fns:
+        return False
+
+    if not isinstance(op_overload, torch._ops.OpOverload):
+        return False
+
+    alias_info = len(
+        [i for i in op_overload._schema.arguments if i.alias_info is not None]
+    )
+
+    is_mutating_or_aliasing = alias_info != 0 or op_overload._schema.is_mutable
+
+    if is_mutating_or_aliasing:
+        return False
+
+    if not torch._C._dispatch_has_kernel(op_overload.name()):
+        return False
+
+    return True

--- a/src/torch_onnx/_decomp.py
+++ b/src/torch_onnx/_decomp.py
@@ -11,9 +11,9 @@ import torch._ops
 from torch_onnx import _registration
 
 
-def _get_registered_ops(
+def get_onnx_implemented_overloads(
     registry: _registration.ONNXRegistry,
-) -> set[torch._ops.OperatorBase | Callable]:
+) -> list[torch._ops.OperatorBase]:
     """
     Creates a set of OperatorBase and Callable objects that represent ONNX-supported PyTorch operations.
 
@@ -23,7 +23,7 @@ def _get_registered_ops(
     Returns:
         A collection of OperatorBase and Callable objects representing ONNX-supported PyTorch operations.
     """
-    registered_ops: set[torch._ops.OperatorBase | Callable] = set()
+    registered_ops: list[torch._ops.OperatorBase] = []
     for op_namespace in (torch.ops.aten, torch.ops.prims):
         op_names = dir(op_namespace)
         for op_name in op_names:
@@ -34,39 +34,13 @@ def _get_registered_ops(
             for overload_name in op_overload_packet.overloads():
                 op_overload = getattr(op_overload_packet, overload_name)
                 if registry.is_registered(op_overload):
-                    registered_ops.add(op_overload)
+                    registered_ops.append(op_overload)
     return registered_ops
 
 
-def create_onnx_friendly_decomposition_table(
-    registry,
-) -> dict[torch._ops.OperatorBase, Callable]:
-    """
-    This function creates a dictionary of op overloads and their decomposition functions
-    for ops that do not have ONNX symbolic functions. If an op already has an ONNX symbolic function,
-    its decomposition function is excluded from the table. The decomposition table is a subset of PyTorch's
-    built-in aten-to-aten decomposition.
-
-    Args:
-        registry: The ONNX registry for PyTorch.
-
-    Returns:
-        Dict[torch._ops.OperatorBase, Callable]: A dictionary that maps op overloads to their corresponding
-        decomposition functions.
-    """
-    decomposition_table: dict[torch._ops.OperatorBase, Callable] = {}
-    onnx_registered_ops = _get_registered_ops(registry)
-
+def full_decomposition_table() -> dict[torch._ops.OperatorBase, Callable]:
+    """Return the full decomposition table."""
     # NOTE: If we import torch._decomp, we will get RuntimeError: Only a single
     # TORCH_LIBRARY can be used to register the namespace nvprims; please put all of your
     # definitions in a single TORCH_LIBRARY block.
-    for op_overload, decomp_fn in torch._decomp.decomposition_table.items():  # type: ignore[attr-defined]
-        # Skip decomposition for op_overload as long as that op_overload has a corresponding ONNX
-        # symbolic function.
-        # NOTE: Do not skip torch._refs decomps. They are fine because otherwise the model is
-        # not exportable anyways.
-        if op_overload in onnx_registered_ops:
-            continue
-        decomposition_table[op_overload] = decomp_fn
-
-    return decomposition_table
+    return torch._decomp.decomposition_table

--- a/src/torch_onnx/_decomp.py
+++ b/src/torch_onnx/_decomp.py
@@ -70,32 +70,3 @@ def create_onnx_friendly_decomposition_table(
         decomposition_table[op_overload] = decomp_fn
 
     return decomposition_table
-
-
-def valid_to_preserve(op_overload: torch._ops.OperatorBase) -> bool:
-    # Adapted from https://github.com/pytorch/pytorch/blob/611c1043709dc04ed500c551aeb40f69e56a1a4f/torch/export/exported_program.py#L177
-    # PyTorch License
-    # TODO(justinchuby): Update when the source changes
-    from torch._subclasses.functional_tensor import FunctionalTensor
-
-    if op_overload in FunctionalTensor.maybe_aliasing_or_mutating_ops:
-        return False
-    if op_overload in FunctionalTensor.metadata_fns:
-        return False
-
-    if not isinstance(op_overload, torch._ops.OpOverload):
-        return False
-
-    alias_info = len(
-        [i for i in op_overload._schema.arguments if i.alias_info is not None]
-    )
-
-    is_mutating_or_aliasing = alias_info != 0 or op_overload._schema.is_mutable
-
-    if is_mutating_or_aliasing:
-        return False
-
-    if not torch._C._dispatch_has_kernel(op_overload.name()):
-        return False
-
-    return True

--- a/src/torch_onnx/_fx_passes.py
+++ b/src/torch_onnx/_fx_passes.py
@@ -22,8 +22,11 @@ def decompose_with_registry(
 
     This function is needed so it shows clearly on the profiler results.
     """
-    decomp_table = _decomp.create_onnx_friendly_decomposition_table(registry)
-    return exported_program.run_decompositions(decomp_table)
+    decomp_table = _decomp.full_decomposition_table()
+    registered_ops = _decomp.get_onnx_implemented_overloads(registry)
+    return exported_program.run_decompositions(
+        decomp_table, _preserve_ops=tuple(registered_ops)
+    )
 
 
 def insert_type_promotion_nodes(

--- a/src/torch_onnx/_fx_passes.py
+++ b/src/torch_onnx/_fx_passes.py
@@ -4,6 +4,7 @@ import torch
 import torch.export
 import torch.fx
 from torch.onnx._internal.fx import diagnostics, passes
+import packaging.version
 
 from torch_onnx import _decomp, _registration
 
@@ -15,6 +16,16 @@ _ATEN_ASSERTION_TARGETS = frozenset(
 )
 
 
+def _torch_older_than(version: str) -> bool:
+    """Returns True if the torch version is older than the given version."""
+    import torch  # pylint: disable=import-outside-toplevel
+
+    return (
+        packaging.version.parse(torch.__version__).release
+        < packaging.version.parse(version).release
+    )
+
+
 def decompose_with_registry(
     exported_program: torch.export.ExportedProgram, registry: _registration.ONNXRegistry
 ) -> torch.export.ExportedProgram:
@@ -22,11 +33,18 @@ def decompose_with_registry(
 
     This function is needed so it shows clearly on the profiler results.
     """
-    decomp_table = _decomp.full_decomposition_table()
-    registered_ops = _decomp.get_onnx_implemented_overloads(registry)
-    return exported_program.run_decompositions(
-        decomp_table, _preserve_ops=tuple(registered_ops)
-    )
+    decomp_table = _decomp.create_onnx_friendly_decomposition_table(registry)
+    if _torch_older_than("2.5"):
+        return exported_program.run_decompositions(decomp_table)
+    else:
+        # The _preserve_ops argument is only available in torch>=2.5
+        implemented_ops = _decomp.get_onnx_implemented_overloads(registry)
+        to_preserve: tuple[torch._ops.OpOverload] = tuple(
+            op for op in implemented_ops if _decomp.valid_to_preserve(op)
+        )
+        return exported_program.run_decompositions(
+            decomp_table, _preserve_ops=to_preserve
+        )
 
 
 def insert_type_promotion_nodes(

--- a/src/torch_onnx/_fx_passes.py
+++ b/src/torch_onnx/_fx_passes.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import packaging.version
 import torch
 import torch.export
 import torch.fx
 from torch.onnx._internal.fx import diagnostics, passes
-import packaging.version
 
 from torch_onnx import _decomp, _registration
 
@@ -42,22 +42,23 @@ def decompose_with_registry(
         # Try to preserve some known CompositeImplicitAutograd ops
         aten = torch.ops.aten
         to_preserve = {
+            aten._upsample_bilinear2d_aa.default,
             aten._upsample_nearest_exact1d.vec,
             aten._upsample_nearest_exact2d.vec,
             aten._upsample_nearest_exact3d.vec,
             aten.linear.default,
-            aten.upsample_bilinear2d_aa.default,
             aten.upsample_bilinear2d.default,
-            aten.upsample_linear1d_aa.default,
+            aten.upsample_bilinear2d.vec,
             aten.upsample_linear1d.default,
+            aten.upsample_linear1d.vec,
             aten.upsample_nearest1d.default,
             aten.upsample_nearest1d.vec,
             aten.upsample_nearest2d.default,
             aten.upsample_nearest2d.vec,
             aten.upsample_nearest3d.default,
             aten.upsample_nearest3d.vec,
-            aten.upsample_trilinear3d_aa.default,
             aten.upsample_trilinear3d.default,
+            aten.upsample_trilinear3d.vec,
         }
         # We can only preserve implemented ops
         can_preserve = tuple(to_preserve.intersection(onnx_registered_ops))

--- a/tests/models/upsample.py
+++ b/tests/models/upsample.py
@@ -18,8 +18,8 @@ def main():
     ).eval()
     data = torch.randn(1, 4, 224, 224, 128)
 
-    program = torch.onnx.export(model, (data,))
-    print(program)
+    # Check that the upsample op is not decomposed
+    torch.onnx.export(model, (data,), "upsample.onnx")
 
 
 if __name__ == "__main__":

--- a/tests/models/upsample.py
+++ b/tests/models/upsample.py
@@ -1,0 +1,26 @@
+import torch
+import torch_onnx
+from monai.networks.nets import SegResNet
+
+torch_onnx.patch_torch(
+    report=True, profile=True, verify=True, dump_exported_program=False, fallback=False
+)
+
+
+def main():
+    model = SegResNet(
+        blocks_down=(1, 2, 2, 4),
+        blocks_up=(1, 1, 1),
+        init_filters=16,
+        in_channels=4,
+        out_channels=3,
+        dropout_prob=0.2,
+    ).eval()
+    data = torch.randn(1, 4, 224, 224, 128)
+
+    program = torch.onnx.export(model, (data,))
+    print(program)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Specify _preserve_ops to prevent upsample and linear from being decomposed.