### PR TITLE
Fix function signature generation when param is not annotated

### DIFF
--- a/src/torch_onnx/_schemas.py
+++ b/src/torch_onnx/_schemas.py
@@ -127,6 +127,8 @@ class Parameter:
 
 @dataclasses.dataclass(frozen=True)
 class AttributeParameter:
+    """A parameter in the function signature that represents an ONNX attribute."""
+
     name: str
     type: ir.AttributeType
     required: bool
@@ -441,7 +443,7 @@ class OpSignature:
         # https://github.com/python/cpython/issues/102405
         type_hints = typing.get_type_hints(func)
 
-        params = []
+        params: list[Parameter | AttributeParameter] = []
         # Create a mapping from type to a unique name
         type_constraints: dict[str, TypeConstraintParam] = {}
 
@@ -452,8 +454,18 @@ class OpSignature:
                     param.name,
                     py_signature,
                 )
-                type_constraints[param.name] = TypeConstraintParam.any_value(
-                    f"T_{param.name}"
+                type_constraint = TypeConstraintParam.any_value(f"T_{param.name}")
+                params.append(
+                    Parameter(
+                        name=param.name,
+                        type_constraint=type_constraint,
+                        required=param.default is inspect.Parameter.empty,
+                        # TODO: Handle variadic
+                        variadic=False,
+                        default=param.default
+                        if param.default is not inspect.Parameter.empty
+                        else _EMPTY_DEFAULT,
+                    )
                 )
             else:
                 type_ = type_hints[param.name]
@@ -496,7 +508,7 @@ class OpSignature:
                         type_constraints[type_constraint_name] = type_constraint
                     # 4. Create Parameter
                     params.append(
-                        Parameter(  # type: ignore[arg-type]
+                        Parameter(
                             name=param.name,
                             type_constraint=type_constraint,
                             required=param.default is inspect.Parameter.empty,


### PR DESCRIPTION
Previously the parameter was not added to the signature. Fixes https://github.com/justinchuby/torch-onnx/issues/175