### PR TITLE
Properly handle Attributes in traceable functions

### DIFF
--- a/src/torch_onnx/_building.py
+++ b/src/torch_onnx/_building.py
@@ -490,6 +490,11 @@ class OpRecorder(evaluator.Evaluator):
             # call because it will filter out the unexpected kwargs for us.
             if function.traceable:
                 # Trace the function call instead of adding the function as a node
+                # Turn the ir.Attr objects into Python constants first
+                named_attrs = {
+                    name: attr.value if isinstance(attr, ir.Attr) else attr
+                    for name, attr in named_attrs.items()
+                }
                 return function.function(**named_inputs, **named_attrs)
 
             outputs = self._call_op(op_signature, named_inputs, named_attrs)

--- a/tests/conversion_test.py
+++ b/tests/conversion_test.py
@@ -171,6 +171,15 @@ class ConversionTest(unittest.TestCase):
         onnx_program = torch_onnx.export(GraphModule(), inputs)
         torch_onnx.testing.assert_onnx_program(onnx_program)
 
+    def test_python_attributes_are_not_turned_into_attr_objects(self):
+        class GraphModule(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.elu(x)
+
+        inputs = (torch.tensor(1.0),)
+        onnx_program = torch_onnx.export(GraphModule(), inputs)
+        torch_onnx.testing.assert_onnx_program(onnx_program)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Previously the attributes were sent in as Attr objects even when we call the function as a plain Python function. Turning them into python objects.
 
Fix https://github.com/microsoft/onnxscript/issues/1846