### PR TITLE
Re-raise the exception if the dynamic shapes cannot be refined

### DIFF
--- a/src/torch_onnx/_capture_strategies.py
+++ b/src/torch_onnx/_capture_strategies.py
@@ -128,11 +128,13 @@ class TorchExportStrategy(CaptureStrategy):
             )
         except torch._dynamo.exc.UserError as exc:
             # Refine the dynamic shapes based on the suggested fixes.
-            new_shapes = (
-                torch.export.dynamic_shapes.refine_dynamic_shapes_from_suggested_fixes(
+            try:
+                new_shapes = torch.export.dynamic_shapes.refine_dynamic_shapes_from_suggested_fixes(
                     exc.msg, dynamic_shapes
                 )
-            )
+            except Exception:
+                # If the dynamic shapes cannot be refined, re-raise the exception.
+                raise exc from None
             return torch.export.export(
                 model, args, kwargs=kwargs, dynamic_shapes=new_shapes
             )
@@ -167,11 +169,13 @@ class TorchExportNonStrictStrategy(CaptureStrategy):
             )
         except torch._dynamo.exc.UserError as exc:
             # Refine the dynamic shapes based on the suggested fixes.
-            new_shapes = (
-                torch.export.dynamic_shapes.refine_dynamic_shapes_from_suggested_fixes(
+            try:
+                new_shapes = torch.export.dynamic_shapes.refine_dynamic_shapes_from_suggested_fixes(
                     exc.msg, dynamic_shapes
                 )
-            )
+            except Exception:
+                # If the dynamic shapes cannot be refined, re-raise the exception.
+                raise exc from None
             return torch.export.export(
                 model, args, kwargs=kwargs, dynamic_shapes=new_shapes, strict=False
             )


### PR DESCRIPTION
Improve error reporting. Otherwise users will just see not being able to refine shapes most of the time.