### PR TITLE
Remove eq to keep SymbolicTensor Hashable; Fix TorchTensor `__array__`

### DIFF
--- a/src/torch_onnx/_core.py
+++ b/src/torch_onnx/_core.py
@@ -99,8 +99,9 @@ class TorchTensor(ir.Tensor):
 
     def __array__(self, dtype: Any = None) -> np.ndarray:
         # numpy() calls __array__ in ir.Tensor
+        self.raw: torch.Tensor
         if self.dtype == ir.DataType.BFLOAT16:
-            return self.raw.view(torch.uint16).__array__(dtype)
+            return self.raw.view(torch.uint16).numpy(force=True).__array__(dtype)
         if self.dtype in {
             ir.DataType.FLOAT8E4M3FN,
             ir.DataType.FLOAT8E4M3FNUZ,
@@ -108,8 +109,8 @@ class TorchTensor(ir.Tensor):
             ir.DataType.FLOAT8E5M2FNUZ,
         }:
             # TODO: Use ml_dtypes
-            return self.raw.view(torch.uint8).__array__(dtype)
-        return self.raw.__array__(dtype)
+            return self.raw.view(torch.uint8).numpy(force=True).__array__(dtype)
+        return self.raw.numpy(force=True).__array__(dtype)
 
     def tobytes(self) -> bytes:
         # Implement tobytes to support native PyTorch types so we can use types like bloat16

--- a/src/torch_onnx/_tensors.py
+++ b/src/torch_onnx/_tensors.py
@@ -88,9 +88,6 @@ class SymbolicTensor(ir.Value):
     def __le__(self, other):
         return self._opset.LessOrEqual(self, other)
 
-    def __eq__(self, other):
-        return self._opset.Equal(self, other)
-
     def __ge__(self, other):
         return self._opset.GreaterOrEqual(self, other)
 

--- a/src/torch_onnx/_tensors_test.py
+++ b/src/torch_onnx/_tensors_test.py
@@ -1,0 +1,19 @@
+# mypy: allow-untyped-defs
+from __future__ import annotations
+
+import unittest
+
+import onnxscript
+
+from torch_onnx import _tensors
+
+
+class SymbolicTensorTest(unittest.TestCase):
+    def test_it_is_hashable(self):
+        tensor = _tensors.SymbolicTensor(opset=onnxscript.values.Opset(domain="test", version=1))
+        self.assertEqual(hash(tensor), hash(tensor))
+        self.assertIn(tensor, set([tensor]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/torch_onnx/_tensors_test.py
+++ b/src/torch_onnx/_tensors_test.py
@@ -10,7 +10,9 @@ from torch_onnx import _tensors
 
 class SymbolicTensorTest(unittest.TestCase):
     def test_it_is_hashable(self):
-        tensor = _tensors.SymbolicTensor(opset=onnxscript.values.Opset(domain="test", version=1))
+        tensor = _tensors.SymbolicTensor(
+            opset=onnxscript.values.Opset(domain="test", version=1)
+        )
         self.assertEqual(hash(tensor), hash(tensor))
         self.assertIn(tensor, set([tensor]))
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/135700